### PR TITLE
Updated trackma-git pkgbuild with new flags for git submodule

### DIFF
--- a/trackma-git/PKGBUILD
+++ b/trackma-git/PKGBUILD
@@ -55,7 +55,7 @@ prepare() {
   cd ${pkgname}
   git submodule init
   git config submodule."trackma/data/anime-relations".url $srcdir/anime-relations
-  git submodule update
+  git -c protocol.file.allow=always submodule update
 }
 
 package() {


### PR DESCRIPTION
Updated the PKGBUILD based on the guidance provided at https://wiki.archlinux.org/title/VCS_package_guidelines to address the changes to git 2.38.1