### PR TITLE
Update PKGBUILD for OpenBangla-Keyboard build issue 

### DIFF
--- a/openbangla-keyboard-git/PKGBUILD
+++ b/openbangla-keyboard-git/PKGBUILD
@@ -49,7 +49,8 @@ build() {
         -DCMAKE_SKIP_INSTALL_RPATH=YES \
         -DCMAKE_SKIP_RPATH=YES \
         -DENABLE_FCITX=YES \
-        -DENABLE_IBUS=YES
+        -DENABLE_IBUS=YES \
+        -DCMAKE_INSTALL_PREFIX="/usr"
     make -C build
 }
 package_openbangla-keyboard-git() {


### PR DESCRIPTION
Added -DCMAKE_INSTALL_PREFIX="/usr" to the build function for issue [#376](https://github.com/OpenBangla/OpenBangla-Keyboard/issues/376)