### PR TITLE
lib32-gst-bad-ugly: 1.24.0-2 -> 1.24.3-1

### DIFF
--- a/lib32-gst-bad-ugly/.SRCINFO
+++ b/lib32-gst-bad-ugly/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = lib32-gst-bad-ugly
 	pkgdesc = Multimedia graph framework (32-bit)
-	pkgver = 1.24.0
-	pkgrel = 2
+	pkgver = 1.24.3
+	pkgrel = 1
 	url = https://gstreamer.freedesktop.org/
 	arch = x86_64
 	license = LGPL
@@ -14,7 +14,7 @@ pkgbase = lib32-gst-bad-ugly
 	makedepends = wayland-protocols
 	makedepends = lib32-gtk3
 	makedepends = python-packaging
-	makedepends = lib32-gst-plugins-base-libs>=1.24.0
+	makedepends = lib32-gst-plugins-base-libs>=1.24.3
 	makedepends = lib32-a52dec
 	makedepends = lib32-libcdio
 	makedepends = lib32-libdvdread
@@ -79,16 +79,16 @@ pkgbase = lib32-gst-bad-ugly
 	makedepends = lib32-json-glib
 	makedepends = lib32-ffmpeg
 	options = !debug
-	source = git+https://gitlab.freedesktop.org/gstreamer/gstreamer.git#tag=1.24.0
+	source = git+https://gitlab.freedesktop.org/gstreamer/gstreamer.git#tag=1.24.3
 	source = 0001-Allow-disabling-gstreamer.patch
 	source = 0002-HACK-meson-Disable-broken-tests.patch
 	sha256sums = SKIP
 	sha256sums = dd928acaa15670225059b36ca5a29d808feba3855700f9b36128a2e55a335a50
-	sha256sums = 3ff4e16e0d64ca935fbcc1ee5338ac815a8682878c2da78b9d0166037949e54e
+	sha256sums = 405adb6bf85b5e130cc1d2ba100abd5fa5c0694ceea3a5082365a966061d7eda
 
 pkgname = lib32-gst-plugins-ugly
 	pkgdesc = Multimedia graph framework (32-bit) - ugly plugins
-	depends = lib32-gst-plugins-base-libs>=1.24.0
+	depends = lib32-gst-plugins-base-libs>=1.24.3
 	depends = lib32-a52dec
 	depends = lib32-libcdio
 	depends = lib32-libdvdread
@@ -99,14 +99,14 @@ pkgname = lib32-gst-plugins-ugly
 
 pkgname = lib32-gst-libav
 	pkgdesc = Multimedia graph framework (32-bit) - libav plugin
-	depends = lib32-gst-plugins-base-libs>=1.24.0
+	depends = lib32-gst-plugins-base-libs>=1.24.3
 	depends = lib32-ffmpeg
-	provides = lib32-gst-ffmpeg=1.24.0
+	provides = lib32-gst-ffmpeg=1.24.3
 	replaces = lib32-gst-libav-latest
 
 pkgname = lib32-gst-plugins-bad-libs
 	pkgdesc = Multimedia graph framework (32-bit) - bad
-	depends = lib32-gst-plugins-base-libs>=1.24.0
+	depends = lib32-gst-plugins-base-libs>=1.24.3
 	depends = lib32-libdrm
 	depends = lib32-libgudev
 	depends = lib32-libusb
@@ -117,7 +117,7 @@ pkgname = lib32-gst-plugins-bad-libs
 
 pkgname = lib32-gst-plugins-bad
 	pkgdesc = Multimedia graph framework (32-bit) - bad plugins
-	depends = lib32-gst-plugins-bad-libs>=1.24.0
+	depends = lib32-gst-plugins-bad-libs>=1.24.3
 	depends = lib32-aom
 	depends = lib32-bzip2
 	depends = lib32-curl

--- a/lib32-gst-bad-ugly/0002-HACK-meson-Disable-broken-tests.patch
+++ b/lib32-gst-bad-ugly/0002-HACK-meson-Disable-broken-tests.patch
@@ -4,27 +4,41 @@ Date: Mon, 6 Jun 2022 00:30:08 +0200
 Subject: [PATCH] HACK: meson: Disable broken tests
 
 ---
- subprojects/gst-editing-services/meson.build                | 1 -
- subprojects/gst-plugins-bad/tests/check/elements/dash_mpd.c | 1 -
- subprojects/gst-plugins-bad/tests/check/meson.build         | 1 -
- subprojects/gst-plugins-good/tests/check/elements/flvmux.c  | 1 -
- subprojects/gst-python/meson.build                          | 1 -
- subprojects/gst-rtsp-server/tests/check/meson.build         | 2 --
- subprojects/gstreamer-vaapi/meson.build                     | 1 -
- 7 files changed, 8 deletions(-)
+ subprojects/gst-editing-services/tests/check/meson.build       | 2 --
+ subprojects/gst-plugins-bad/tests/check/elements/curlhttpsrc.c | 1 -
+ subprojects/gst-plugins-bad/tests/check/elements/dash_mpd.c    | 1 -
+ subprojects/gst-plugins-bad/tests/check/elements/lc3.c         | 3 ---
+ subprojects/gst-plugins-bad/tests/check/meson.build            | 1 -
+ subprojects/gst-plugins-bad/tests/validate/meson.build         | 3 ---
+ subprojects/gst-plugins-base/tests/validate/meson.build        | 1 -
+ subprojects/gst-plugins-good/tests/check/elements/flvmux.c     | 1 -
+ subprojects/gstreamer-vaapi/meson.build                        | 1 -
+ 9 files changed, 14 deletions(-)
 
-diff --git a/subprojects/gst-editing-services/meson.build b/subprojects/gst-editing-services/meson.build
-index 968671934c4e..9741838d67b9 100644
---- a/subprojects/gst-editing-services/meson.build
-+++ b/subprojects/gst-editing-services/meson.build
-@@ -295,7 +295,6 @@ subdir('ges')
- subdir('plugins')
- subdir('tools')
+diff --git a/subprojects/gst-editing-services/tests/check/meson.build b/subprojects/gst-editing-services/tests/check/meson.build
+index 784c592ba6f1..bbf9a2491a86 100644
+--- a/subprojects/gst-editing-services/tests/check/meson.build
++++ b/subprojects/gst-editing-services/tests/check/meson.build
+@@ -144,7 +144,5 @@ if build_gir
+     env.set('GST_PLUGIN_PATH_1_0', [meson.global_build_root()] + pluginsdirs)
+     env.set('GI_TYPELIB_PATH', meson.current_build_dir() / '..' / '..' / 'ges')
  
--subdir('tests')
- subdir('examples')
- subdir('docs')
+-    test('pythontests', runtests, args: ['--pyunittest-dir', meson.current_source_dir(), 'pyunittest', '--dump-on-failure'],
+-         env: env)
+   endif
+ endif
+diff --git a/subprojects/gst-plugins-bad/tests/check/elements/curlhttpsrc.c b/subprojects/gst-plugins-bad/tests/check/elements/curlhttpsrc.c
+index d0901d5b23df..62b3bba4b614 100644
+--- a/subprojects/gst-plugins-bad/tests/check/elements/curlhttpsrc.c
++++ b/subprojects/gst-plugins-bad/tests/check/elements/curlhttpsrc.c
+@@ -910,7 +910,6 @@ curlhttpsrc_suite (void)
+   tcase_add_test (tc_chain, test_forbidden);
+   tcase_add_test (tc_chain, test_cookies);
+   tcase_add_test (tc_chain, test_multiple_http_requests);
+-  tcase_add_test (tc_chain, test_range_get);
  
+   return s;
+ }
 diff --git a/subprojects/gst-plugins-bad/tests/check/elements/dash_mpd.c b/subprojects/gst-plugins-bad/tests/check/elements/dash_mpd.c
 index 1d347b0a54ea..1ee4babf36ae 100644
 --- a/subprojects/gst-plugins-bad/tests/check/elements/dash_mpd.c
@@ -37,11 +51,25 @@ index 1d347b0a54ea..1ee4babf36ae 100644
  
    /* tests checking the MPD management
     * (eg. setting active streams, obtaining attributes values)
+diff --git a/subprojects/gst-plugins-bad/tests/check/elements/lc3.c b/subprojects/gst-plugins-bad/tests/check/elements/lc3.c
+index 5ee2ca1efaac..a6a692ee26a1 100644
+--- a/subprojects/gst-plugins-bad/tests/check/elements/lc3.c
++++ b/subprojects/gst-plugins-bad/tests/check/elements/lc3.c
+@@ -429,9 +429,6 @@ lc3_suite (void)
+   TCase *tc_chain = tcase_create ("general");
+ 
+   suite_add_tcase (s, tc_chain);
+-  tcase_add_test (tc_chain, test_48k_8ch_10000us);
+-  tcase_add_test (tc_chain, test_48k_8ch_7500us);
+-  tcase_add_test (tc_chain, test_24k_4ch_10000us);
+   tcase_add_test (tc_chain, test_dec_plc);
+ 
+   return s;
 diff --git a/subprojects/gst-plugins-bad/tests/check/meson.build b/subprojects/gst-plugins-bad/tests/check/meson.build
-index c21887d99ed1..4da79603f5bc 100644
+index 3c64a3641aa7..dc00f8d81b0a 100644
 --- a/subprojects/gst-plugins-bad/tests/check/meson.build
 +++ b/subprojects/gst-plugins-bad/tests/check/meson.build
-@@ -145,7 +145,6 @@ if host_machine.system() != 'windows'
+@@ -152,7 +152,6 @@ if host_machine.system() != 'windows'
      [['elements/jifmux.c'],
          not exif_dep.found() or not cdata.has('HAVE_UNISTD_H'), [exif_dep]],
      [['elements/jpegparse.c'], not cdata.has('HAVE_UNISTD_H')],
@@ -49,6 +77,38 @@ index c21887d99ed1..4da79603f5bc 100644
      [['elements/shm.c'], not shm_enabled, shm_deps],
      [['elements/unixfd.c'], not gio_unix_dep.found()],
      [['elements/voaacenc.c'],
+diff --git a/subprojects/gst-plugins-bad/tests/validate/meson.build b/subprojects/gst-plugins-bad/tests/validate/meson.build
+index c09772a657f4..6dd292ea670a 100644
+--- a/subprojects/gst-plugins-bad/tests/validate/meson.build
++++ b/subprojects/gst-plugins-bad/tests/validate/meson.build
+@@ -4,15 +4,12 @@ if not gst_tester.found()
+ endif
+ 
+ tests = [
+-    {'path': 'opencv/cvtracker'},
+     {'path': 'testsrcbin/caps_spec'},
+     {'path': 'codectimestamper/h264_propagate_caps'},
+-    {'path': 'wpe/load_bytes_first', 'skip': not building_wpe},
+     {'path': 'vtenc/vtenc_h264', 'skip': not applemedia_found_deps},
+     {'path': 'vtenc/vtenc_h264_b_frames', 'skip': not applemedia_found_deps},
+     {'path': 'vtenc/vtenc_h265', 'skip': not applemedia_found_deps},
+     {'path': 'vtenc/vtenc_h265_b_frames', 'skip': not applemedia_found_deps},
+-    {'path': 'autovideoconvert/renegotiate'},
+ ]
+ 
+ env = environment()
+diff --git a/subprojects/gst-plugins-base/tests/validate/meson.build b/subprojects/gst-plugins-base/tests/validate/meson.build
+index f732daae44c5..bc89d8caa676 100644
+--- a/subprojects/gst-plugins-base/tests/validate/meson.build
++++ b/subprojects/gst-plugins-base/tests/validate/meson.build
+@@ -20,7 +20,6 @@ tests = [
+     'videorate/duplicate_on_eos',
+     'videorate/duplicate_on_eos_disbaled',
+     'videorate/duplicate_on_eos_half_sec',
+-    'videorate/fill_segment_after_caps_changed_before_eos',
+     'videorate/drop_out_of_segment',
+     'compositor/renogotiate_failing_unsupported_src_format',
+     'giosrc/read-growing-file',
 diff --git a/subprojects/gst-plugins-good/tests/check/elements/flvmux.c b/subprojects/gst-plugins-good/tests/check/elements/flvmux.c
 index 6efa928fb09b..1f1950ef323d 100644
 --- a/subprojects/gst-plugins-good/tests/check/elements/flvmux.c
@@ -61,33 +121,8 @@ index 6efa928fb09b..1f1950ef323d 100644
    tcase_add_test (tc_chain, test_audio_caps_change_streamable);
    tcase_add_test (tc_chain, test_video_caps_change_streamable);
    tcase_add_test (tc_chain, test_audio_caps_change_streamable_single);
-diff --git a/subprojects/gst-python/meson.build b/subprojects/gst-python/meson.build
-index d2b994288d4a..00df444f18fa 100644
---- a/subprojects/gst-python/meson.build
-+++ b/subprojects/gst-python/meson.build
-@@ -132,5 +132,4 @@ if not get_option('plugin').disabled()
-   endif
- endif
- if not get_option('tests').disabled()
--  subdir('testsuite')
- endif
-diff --git a/subprojects/gst-rtsp-server/tests/check/meson.build b/subprojects/gst-rtsp-server/tests/check/meson.build
-index 2112da396235..1cbcb861dcf4 100644
---- a/subprojects/gst-rtsp-server/tests/check/meson.build
-+++ b/subprojects/gst-rtsp-server/tests/check/meson.build
-@@ -28,10 +28,8 @@ rtsp_server_tests = [
-   'gst/mediafactory',
-   'gst/media',
-   'gst/permissions',
--  'gst/rtspserver',
-   'gst/sessionmedia',
-   'gst/sessionpool',
--  'gst/stream',
-   'gst/threadpool',
-   'gst/token',
-   'gst/onvif',
 diff --git a/subprojects/gstreamer-vaapi/meson.build b/subprojects/gstreamer-vaapi/meson.build
-index e5b03a30b98e..0044bc4ad979 100644
+index c470158893f3..cee44f2e7480 100644
 --- a/subprojects/gstreamer-vaapi/meson.build
 +++ b/subprojects/gstreamer-vaapi/meson.build
 @@ -218,7 +218,6 @@ plugins = []

--- a/lib32-gst-bad-ugly/PKGBUILD
+++ b/lib32-gst-bad-ugly/PKGBUILD
@@ -15,8 +15,8 @@ pkgname=(lib32-gst-plugins-ugly)
 )
 readonly LIB32GST_DISABLE_{AV,BAD}
 
-pkgver=1.24.0
-pkgrel=2
+pkgver=1.24.3
+pkgrel=1
 pkgdesc="Multimedia graph framework (32-bit)"
 url="https://gstreamer.freedesktop.org/"
 arch=(x86_64)
@@ -97,7 +97,7 @@ source=(
 )
 sha256sums=('SKIP'
             'dd928acaa15670225059b36ca5a29d808feba3855700f9b36128a2e55a335a50'
-            '3ff4e16e0d64ca935fbcc1ee5338ac815a8682878c2da78b9d0166037949e54e')
+            '405adb6bf85b5e130cc1d2ba100abd5fa5c0694ceea3a5082365a966061d7eda')
 #validpgpkeys=(D637032E45B8C6585B9456565D2EEE6F6F349D7C) # Tim Müller <tim@gstreamer-foundation.org>
 
 pkgver() {
@@ -230,6 +230,8 @@ build() {
 check() (
 	export XDG_RUNTIME_DIR="$PWD/runtime-dir"
 	mkdir -p -m 700 "$XDG_RUNTIME_DIR"
+
+	export NO_AT_BRIDGE=1 GTK_A11Y=none
 
 	# Flaky due to timeouts
 	xvfb-run -s '-nolisten local' \


### PR DESCRIPTION
I've also synced `0002-HACK-meson-Disable-broken-tests.patch` (from `lib32-gstreamer`) and also added `export NO_AT_BRIDGE=1 GTK_A11Y=none` into `check()` (because `lib32-gstreamer`,`gstreamer` also added them)