### PR TITLE
Use original submodules for openbangla-keyboard-git

### DIFF
--- a/openbangla-keyboard-git/PKGBUILD
+++ b/openbangla-keyboard-git/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=(
     "ibus-openbangla-git"
     "fcitx5-openbangla-git"
 )
-pkgver=2.0.0.r78.gaddbd4e
+pkgver=2.0.0.r107.gbe784f6
 pkgrel=1
 pkgdesc="An OpenSource, Unicode compliant Bengali Input Method"
 arch=('x86_64')
@@ -18,10 +18,8 @@ optdepends=('ttf-indic-otf: fonts for Bangla and other Indic scripts'
             'ttf-freebanglafont: miscellaneous fonts for Bangla script')
 source=(
     "${pkgbase%*-git}::git+https://github.com/OpenBangla/OpenBangla-Keyboard#branch=develop"
-    "riti::git+https://github.com/OpenBangla/riti"
 )
-sha256sums=('SKIP'
-            'SKIP')
+sha256sums=('SKIP')
 pkgver()
 {
     cd "$srcdir/${pkgbase%*-git}"
@@ -34,10 +32,7 @@ pkgver()
 
 prepare() {
     cd "$srcdir/${pkgbase%*-git}"
-    git submodule init
-    git config submodule."src/engine/riti".url $srcdir/riti
-    git -c protocol.file.allow=always submodule update
-    git -C src/engine/riti checkout master
+    git submodule update --init --recursive
 }
 
 build() {


### PR DESCRIPTION
This [recent commit to riti](https://github.com/OpenBangla/riti/commit/070d7bbff1a04f07afbf14539839a9e6a4c847ac) broke builds. (Well not really recent anymore, it was when I flagged the package out-of-date on the AUR lol)
One way to fix this is to do something [like this](https://github.com/OpenBangla/OpenBangla-Keyboard/compare/develop...zihadmahiuddin:OpenBangla-Keyboard:develop) (maybe apply as a patch).
But the better solution IMO is to not make it fetch the latest commit of riti and instead use the one that's "pinned" on the OBK repo.
I don't think it's a good idea to not use the specified commits for submodules, because then you can't ask them to fix it either.